### PR TITLE
Move Port initialization out of unsafe code block

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -28,8 +28,8 @@ pub enum QemuExitCode {
 pub fn exit_qemu(exit_code: QemuExitCode) {
     use x86_64::instructions::port::Port;
 
+    let mut port = Port::new(0xf4);
     unsafe {
-        let mut port = Port::new(0xf4);
         port.write(exit_code as u32);
     }
 }


### PR DESCRIPTION
I'm excited at the development of this project! I love the idea and I hope to see it grow.

After doing some testing, I found that the operating system ran the same for me when the `Port::new()` initialization was moved outside of the `unsafe` code block. Therefore, in order to reduce the number of `unsafe` lines, it would make sense to move this line out.