### PR TITLE
slog overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 run-args=[
     # Add a network for the future
     # "-net", "nic,model=pcnet"
+    # this allows log messages to be printed outside qemu
+    "-serial", "stdio"
 ]
 test-args = [
     "-device", "isa-debug-exit,iobase=0xf4,iosize=0x04",

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -1,16 +1,13 @@
 use crate::{
-    log,
-    // println,
-    LogLevel,
+    success
 };
 
 pub fn aes_detect() -> bool {
     if core_detect::is_x86_feature_detected!("aes") {
-        log(LogLevel::Success);
-        // println!("AES is available");
+        success!("AES is available");
         true
     } else {
-        log(LogLevel::Debug);
+        // log(LogLevel::Debug);
         // println!("AES is not available");
         false
     }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,9 +1,54 @@
+use crate::serial;
 use crate::{
     // print,
     serial_print,
+    serial_println
     // vga_buffer,
 };
 use lliw::Fg;
+use core::fmt::Arguments;
+
+
+/// print an error message to serial, this will append a newline to the end
+
+// Reason; this will definitely get used in the future
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)+) => (
+        $crate::logger::slog($crate::logger::LogLevel::Error, format_args!($($arg)+))
+    )
+}
+
+
+/// print a debug message to serial, this will append a newline to the end
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)+) => (
+        $crate::logger::slog($crate::logger::LogLevel::Debug, format_args!($($arg)+))
+    )
+}
+
+
+/// print a success message to serial, this will append a newline to the end
+
+#[macro_export]
+macro_rules! success {
+    ($($arg:tt)+) => (
+        $crate::logger::slog($crate::logger::LogLevel::Success, format_args!($($arg)+))
+    )
+}
+
+/// print a info message to serial, this will append a newline to the end
+
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)+) => (
+        $crate::logger::slog($crate::logger::LogLevel::Info, format_args!($($arg)+))
+    )
+}
+
+
 
 // use crate::util::{term_reset, term_set};
 /// Denote log levels
@@ -17,6 +62,8 @@ pub enum LogLevel {
     /// Used for successful things
     Success,
 }
+
+
 /// print a log prefix to the framebuffer
 pub fn log(level: LogLevel) {
     // print!("[");
@@ -50,8 +97,11 @@ fn debug_log() {
     // term_reset();
 }
 
-/// print a log prefix to the serial port
-pub fn slog(level: LogLevel) {
+
+
+/// print a log message to the serial port, a newline will be appended.
+/// This should not be used, use the macros named by log levels instead.
+pub fn slog(level: LogLevel, message_args: Arguments) {
     serial_print!("[");
 
     match level {
@@ -60,8 +110,10 @@ pub fn slog(level: LogLevel) {
         LogLevel::Info => info_slog(),
         LogLevel::Success => success_slog(),
     }
-
     serial_print!("] ");
+    serial::_print(message_args);
+    serial_println!();
+
 }
 fn error_slog() {
     serial_print!("{}Error{}", Fg::Red, Fg::Reset);
@@ -70,7 +122,7 @@ fn success_slog() {
     serial_print!("{}Success{}", Fg::Green, Fg::Reset);
 }
 fn info_slog() {
-    // print!("Info");
+    serial_print!("Info");
 }
 fn debug_slog() {
     serial_print!("{}Debug{}", Fg::Yellow, Fg::Reset);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,13 +9,13 @@
 #![feature(alloc_error_handler)] // at the top of the file
 #![feature(const_mut_refs)]
 #![feature(asm)]
-#![warn(missing_docs)]
-// #![deny(missing_docs)]
+#![deny(missing_docs)]
 
 /// TODO: owo what is this?
 pub const KERNEL_VERSION: &str = env!("CARGO_PKG_VERSION");
 const BANNER: &str = include_str!("../root/banner.txt");
 
+/// todo: owo
 #[cfg(debug_assertions)]
 pub const RELEASE_TYPE: &str = "debug";
 #[cfg(not(debug_assertions))]
@@ -43,7 +43,6 @@ mod vga_buffer;
 
 /// Asyncronous module
 pub mod task;
-use logger::{log, LogLevel};
 
 /// The holder of tests
 #[cfg(test)]
@@ -65,7 +64,7 @@ pub extern "C" fn __impl_start(boot_info: &'static ::bootloader::bootinfo::BootI
 
     f(boot_info)
 }
-
+/// todo: owo
 pub struct KernelState<'a> {
     /// The first value is the release state and the second is the version string
     version: (bool, &'a str),
@@ -122,8 +121,9 @@ fn kernel_main(boot_info: &'static BootInfo) -> ! {
     let v_str = format!("version {} {}", KERNEL_VERSION, RELEASE_TYPE);
     println(&v_str, (0, 0));
 
+
     #[cfg(test)]
-    test_main();
+        test_main();
     use task::{executor::Executor, keyboard, Task};
     let mut executor = Executor::new();
     executor.spawn(Task::new(example_task()));
@@ -135,12 +135,10 @@ fn kernel_main(boot_info: &'static BootInfo) -> ! {
 pub fn init() {
     gdt::init();
     interrupts::init_idt();
-
     unsafe { interrupts::pic::PICS.lock().initialize() }; // new
     x86_64::instructions::interrupts::enable(); // new
     if encrypt::aes_detect() {
-        log(LogLevel::Success);
-        // println!("Encryption driver loaded");
+        success!("Encryption driver loaded")
     }
 
     sri::init();
@@ -164,8 +162,7 @@ fn init_alloc(boot_info: &'static BootInfo) {
     let mut frame_allocator = unsafe { BootInfoFrameAllocator::init(&boot_info.memory_map) };
     allocator::init_heap(&mut mapper, &mut frame_allocator).expect("heap initialization failed");
 
-    log(LogLevel::Success);
-    // println!("Allocator loaded");
+    success!("Allocator loaded");
 }
 
 // async fn async_number() -> u32 {

--- a/src/sri/mod.rs
+++ b/src/sri/mod.rs
@@ -1,4 +1,4 @@
-use crate::logger::{log, LogLevel};
+use crate::{info, success};
 use core::fmt;
 
 #[allow(dead_code)]
@@ -23,8 +23,7 @@ impl<'a> fmt::Display for SRI<'a> {
 }
 
 pub fn init() {
-    log(LogLevel::Info);
-    // println!("SRI interface loading");
+    info!("SRI interface loading");
 
     // let url = SRI {
     //     protocol: Protocol::File,
@@ -32,8 +31,7 @@ pub fn init() {
     //     query: "read",
     // };
     // println!("> {}", url);
-    log(LogLevel::Success);
-    // println!("SRI interface loaded");
+    success!("SRI interface loaded")
 }
 
 #[test_case]

--- a/src/task/keyboard.rs
+++ b/src/task/keyboard.rs
@@ -1,4 +1,3 @@
-// use crate::{print, println};
 use conquer_once::spin::OnceCell;
 use core::{
     pin::Pin,
@@ -9,8 +8,8 @@ use futures_util::{
     stream::{Stream, StreamExt},
     task::AtomicWaker,
 };
-use pc_keyboard::{layouts, HandleControl, Keyboard, ScancodeSet1};
-
+use pc_keyboard::{layouts, HandleControl, Keyboard, ScancodeSet1, DecodedKey};
+use crate::debug;
 static SCANCODE_QUEUE: OnceCell<ArrayQueue<u8>> = OnceCell::uninit();
 static WAKER: AtomicWaker = AtomicWaker::new();
 
@@ -74,11 +73,13 @@ pub async fn print_keypresses() {
 
     while let Some(scancode) = scancodes.next().await {
         if let Ok(Some(key_event)) = keyboard.add_byte(scancode) {
-            if let Some(_key) = keyboard.process_keyevent(key_event) {
-                // match key {
-                //     DecodedKey::Unicode(character) => print!("{}", character),
-                //     DecodedKey::RawKey(key) => print!("{:?}", key),
-                // }
+            if let Some(key) = keyboard.process_keyevent(key_event) {
+                match key {
+                    DecodedKey::Unicode(character) => debug!("{:?} is pressed", character),
+                    DecodedKey::RawKey(key) => debug!("{:?} is pressed", key),
+                }
+
+
             }
         }
     }


### PR DESCRIPTION
- added `-serial` `stdio` to run-args in `cargo.toml` for convinient log message display.
- created `error!` `info!` `debug!` `success!` macros for slog